### PR TITLE
Refactor to make Repository objects actors

### DIFF
--- a/BikeTrack.xcodeproj/project.pbxproj
+++ b/BikeTrack.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		63A419252A9F52A400F63F68 /* CurrentValueAsycSequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63A419242A9F52A400F63F68 /* CurrentValueAsycSequence.swift */; };
 		A1A364FF2A9845A500C929C1 /* BikeTrackApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A364FE2A9845A500C929C1 /* BikeTrackApp.swift */; };
 		A1A365012A9845A500C929C1 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A365002A9845A500C929C1 /* ContentView.swift */; };
 		A1A365032A9845A600C929C1 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A1A365022A9845A600C929C1 /* Assets.xcassets */; };
@@ -58,6 +59,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		63A419242A9F52A400F63F68 /* CurrentValueAsycSequence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentValueAsycSequence.swift; sourceTree = "<group>"; };
 		A1A364FB2A9845A500C929C1 /* BikeTrack.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BikeTrack.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A1A364FE2A9845A500C929C1 /* BikeTrackApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BikeTrackApp.swift; sourceTree = "<group>"; };
 		A1A365002A9845A500C929C1 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -148,6 +150,7 @@
 				A1A3652D2A9847F800C929C1 /* UserService.swift */,
 				A1A365382A984E2100C929C1 /* ContentService.swift */,
 				A1A365522A98BE1700C929C1 /* Navigation.swift */,
+				63A419242A9F52A400F63F68 /* CurrentValueAsycSequence.swift */,
 				A1A365332A98495000C929C1 /* Model */,
 				A1A3652A2A9845F400C929C1 /* AuthRepository */,
 				A1A3653A2A984EB900C929C1 /* ContentRepository */,
@@ -386,6 +389,7 @@
 				A1A3653C2A984EDC00C929C1 /* ContentRepository.swift in Sources */,
 				A1A365532A98BE1700C929C1 /* Navigation.swift in Sources */,
 				A1A365512A989AE100C929C1 /* CredentialFormView.swift in Sources */,
+				63A419252A9F52A400F63F68 /* CurrentValueAsycSequence.swift in Sources */,
 				A1A365372A984DD200C929C1 /* AuthorisedContentView.swift in Sources */,
 				A1A365462A9863F600C929C1 /* UserService+Preview.swift in Sources */,
 				A1A365322A9848AC00C929C1 /* AuthRepository.swift in Sources */,

--- a/BikeTrack/AuthRepository/AuthRepository.swift
+++ b/BikeTrack/AuthRepository/AuthRepository.swift
@@ -46,6 +46,23 @@ enum AuthState: Equatable {
     case signedIn(profile: UserProfile)
 }
 
+extension AuthState: CustomStringConvertible {
+    /// Implementing CustomStringConvertible to ensure that profile details
+    /// are not leaked if logging current state.
+    var description: String {
+        switch self {
+        case .unknown:
+            return "unknown"
+        case .loading:
+            return "loading"
+        case .signedOut:
+            return "signedOut"
+        case .signedIn:
+            return "signedIn"
+        }
+    }
+}
+
 protocol AuthRepository {
     /**
      The auth state is a current value sequence that can be observed by any parts of the app

--- a/BikeTrack/AuthRepository/AuthRepository.swift
+++ b/BikeTrack/AuthRepository/AuthRepository.swift
@@ -48,7 +48,7 @@ enum AuthState: Equatable {
 
 protocol AuthRepository {
     /**
-     The current auth state is a current value sequencet that can be observed by any parts of the app
+     The auth state is a current value sequence that can be observed by any parts of the app
      that need to change in response to whether a user is signed in or not.
      */
     var authState: CurrentValueAsyncSequence<AuthState> { get }

--- a/BikeTrack/AuthRepository/AuthRepository.swift
+++ b/BikeTrack/AuthRepository/AuthRepository.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Combine
 
 enum AuthError: LocalizedError, Equatable {
     case userNotFound(String)
@@ -49,10 +48,10 @@ enum AuthState: Equatable {
 
 protocol AuthRepository {
     /**
-     The current auth state is a current value subject that can be observed by any parts of the app
+     The current auth state is a current value sequencet that can be observed by any parts of the app
      that need to change in response to whether a user is signed in or not.
      */
-    var authState: CurrentValueSubject<AuthState, Never> { get }
+    var authState: CurrentValueAsyncSequence<AuthState> { get }
 
     /**
      Initiate a sign in with the username and password that has been provided.

--- a/BikeTrack/AuthRepository/MockAuthRepository.swift
+++ b/BikeTrack/AuthRepository/MockAuthRepository.swift
@@ -1,8 +1,7 @@
 import Foundation
-import Combine
 import OSLog
 
-class MockAuthRepository: AuthRepository {
+actor MockAuthRepository: AuthRepository {
     private static let logger = Logger(
         subsystem: Bundle.main.bundleIdentifier ?? AppEnvironment.defaultBundleID,
         category: String(describing: MockAuthRepository.self)
@@ -10,7 +9,7 @@ class MockAuthRepository: AuthRepository {
     
     private var userDatabase: [MockUser] = []
     
-    var authState: CurrentValueSubject<AuthState, Never>  = .init(.unknown)
+    let authState: CurrentValueAsyncSequence<AuthState> = CurrentValueAsyncSequence(.unknown)
     
     init() {
 #if !DEBUG

--- a/BikeTrack/ContentRepository/ContentRepository.swift
+++ b/BikeTrack/ContentRepository/ContentRepository.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Combine
 
 enum ContentError: LocalizedError, Equatable {
     case userNotFound

--- a/BikeTrack/ContentRepository/InMemoryContentRepository.swift
+++ b/BikeTrack/ContentRepository/InMemoryContentRepository.swift
@@ -1,8 +1,7 @@
 import Foundation
-import Combine
 import OSLog
 
-class InMemoryContentRepository: ContentRepository {
+actor InMemoryContentRepository: ContentRepository {
     
     private static let logger = Logger(
         subsystem: Bundle.main.bundleIdentifier ?? AppEnvironment.defaultBundleID,

--- a/BikeTrack/ContentService.swift
+++ b/BikeTrack/ContentService.swift
@@ -7,6 +7,7 @@ import os.log
  Being an observable object, `ContentService` is intended to be initialised as an `ObservableObject` high up in the SwiftUI view hierarchy and observed as an EnvironmentObject by child views as required.
  Like other `[Name]Service` classes, `ContentService` provides a layer of abstraction between the UI and lower level repositories, which can be swapped out at `init()`.
  */
+@MainActor
 class ContentService: ObservableObject {
     private static let logger = Logger(
         subsystem: Bundle.main.bundleIdentifier ?? AppEnvironment.defaultBundleID,

--- a/BikeTrack/ContentService.swift
+++ b/BikeTrack/ContentService.swift
@@ -1,6 +1,5 @@
 import Foundation
 import os.log
-import Combine
 
 /**
  `ContentService` provides an interface into storing and retrieving user content.
@@ -15,7 +14,6 @@ class ContentService: ObservableObject {
     )
     
     private var contentRepository: ContentRepository
-    private var cancellables = Set<AnyCancellable>()
 
     @Published private (set) var signInState: AuthState = .unknown
     

--- a/BikeTrack/CurrentValueAsycSequence.swift
+++ b/BikeTrack/CurrentValueAsycSequence.swift
@@ -1,0 +1,58 @@
+//
+//  CurrentValueAsycSequence.swift
+//  BikeTrack
+//
+//  Created by Mark Renaud on 30/8/2023.
+//
+
+import Foundation
+
+/**
+ A `AsyncSequence` based replacement for `CurrentValueSubject` publisher from the
+ `Combine` framework.
+ */
+public final class CurrentValueAsyncSequence<T>: AsyncSequence {
+    public typealias Element = T
+
+    private var currentValue: T
+    /// current 'subscribers' listening for new values in the sequence
+    private var listeners: [(T) -> Void] = []
+
+    public init(_ initialValue: T) {
+        self.currentValue = initialValue
+    }
+
+    public func makeAsyncIterator() -> AsyncStream<T>.Iterator {
+        let x = AsyncStream<T> { continuation in
+            // Subscribe to changes
+            self.listeners.append { newValue in
+                continuation.yield(newValue)
+            }
+
+            // Send the initial value
+            continuation.yield(self.currentValue)
+        }.makeAsyncIterator()
+        return x
+    }
+
+    /// updates the current value and sends to listeners watching
+    /// for changes in the sequence
+    public func send(_ newValue: T) {
+        currentValue = newValue
+        for listener in listeners {
+            listener(newValue)
+        }
+    }
+    
+    /// A convenience to observe changes in the currentValue via a Task that executes
+    /// the passed in closure on the Main
+    public func observeOnMain(onChange: @escaping (_ newValue: T) -> ()) -> Task<Void, Never> {
+        return Task {
+            for await newValue in self {
+                await MainActor.run {
+                    onChange(newValue)
+                }
+            }
+        }
+    }
+}

--- a/BikeTrack/UserService.swift
+++ b/BikeTrack/UserService.swift
@@ -7,6 +7,7 @@ import os.log
  Being an observable object, `UserService` is intended to be initialised as an `ObservableObject` high up in the SwiftUI view hierarchy and observed as an EnvironmentObject by child views as required.
  Like other `[Name]Service` classes, `UserService` provides a layer of abstraction between the UI and lower level repositories, which can be swapped out at `init()`.
  */
+@MainActor
 class UserService: ObservableObject {
     private static let logger = Logger(
         subsystem: Bundle.main.bundleIdentifier ?? AppEnvironment.defaultBundleID,

--- a/BikeTrack/UserService.swift
+++ b/BikeTrack/UserService.swift
@@ -19,9 +19,7 @@ class UserService: ObservableObject {
     
     @Published private(set) var authState: AuthState = .unknown {
         didSet {
-            #if DEBUG
-            print("published authState changed to:", authState)
-            #endif
+            Self.logger.info("published authState changed to: \(self.authState)")
         }
     }
     

--- a/BikeTrackTests/BikeTrackTests.swift
+++ b/BikeTrackTests/BikeTrackTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 @testable import BikeTrack
 
+@MainActor  // Isolate test class to MainActor
 final class BikeTrackTests: XCTestCase {
     let mockUserService = UserService(authRepository: MockAuthRepository())
     


### PR DESCRIPTION
Improve safety of `Repository` objects by converting them to actors instead of classes.

Remove dependency on the `Combine` framework and replace it with `AsyncSequence` for state observation. This is required to allow the `Repository` to switch to classes without needing to resort to `nonisolated` annotations for `CurrentValueSubject` publishers.
